### PR TITLE
Add HCA import rules and items description

### DIFF
--- a/datamodel/config/config_schema.json
+++ b/datamodel/config/config_schema.json
@@ -4,10 +4,6 @@
   "description": "The mapping instructions used for JSON to data model conversion.",
   "version": "0.0.1",
   "properties": {
-    "submittables": {
-      "description": "The top level import instructions how to import the main JSON objects that map to the submittable classes, e.g. project, study, samples.",
-      "$ref": "#/definitions/mapping"
-    },
     "project": {
       "$ref": "#/definitions/mapping"
     },

--- a/datamodel/config/datamodel_mapping_config.json
+++ b/datamodel/config/datamodel_mapping_config.json
@@ -108,7 +108,7 @@
     "publications": {
       "description": "list of Publication class objects",
       "type": "array",
-      "items": "Publication",
+      "items": "publication",
       "import": {
         "ae": {
           "path": ["publications"],
@@ -127,7 +127,7 @@
     "contacts": {
       "description": "list of Contact class objects",
       "type": "array",
-      "items": "Contact",
+      "items": "contact",
       "import": {
         "ae": {
           "path": ["contacts"],
@@ -234,7 +234,7 @@
     "experimental_factor": {
       "description": "list of experimental factors as Attribute class objects",
       "type": "array",
-      "items": "Attribute",
+      "items": "attribute",
       "import": {
         "ae": {
           "path": [
@@ -249,7 +249,7 @@
     "experimental_design": {
       "description": "(optional) list of experimental designs as Attribute class objects",
       "type": "array",
-      "items": "Attribute",
+      "items": "attribute",
       "import": {
         "ae": {
           "path": [
@@ -1510,7 +1510,7 @@
     "files": {
       "description": "list of DataFile class objects",
       "type": "array",
-      "items": "DataFile",
+      "items": "data_file",
       "import": {
         "ae": {
           "from_type": "array",
@@ -1609,7 +1609,7 @@
     "files": {
       "description": "list of DataFile class objects",
       "type": "array",
-      "items": "DataFile",
+      "items": "data_file",
       "import": {
         "ae": {
           "from_type": "array",
@@ -1980,6 +1980,50 @@
           "method": "import_string_from_selected_entity"
         }
       }
+    }
+  },
+  "attribute": {
+    "value": {
+      "description": "attribute value, e.g. ontology label",
+      "type": "string",
+      "import": {}
+    },
+    "unit": {
+      "description": "unit object to describe unit value and ontology term",
+      "type": "unit",
+      "import": {}
+    },
+    "term_source": {
+      "description": "the source ontology of the term",
+      "type": "string",
+      "import": {}
+    },
+    "term_accession": {
+      "description": "the ontology ID of the term",
+      "type": "string",
+      "import": {}
+    }
+  },
+  "unit": {
+    "value": {
+      "description": "the unit term, e.g. hour",
+      "type": "string",
+      "import": {}
+    },
+    "unit_type": {
+      "description": "the type of unit, e.g. time unit",
+      "type": "string",
+      "import": {}
+    },
+    "term_source": {
+      "description": "the source ontology of the unit term",
+      "type": "string",
+      "import": {}
+    },
+    "term_accession": {
+      "description": "the ontology ID of the unit term",
+      "type": "string",
+      "import": {}
     }
   }
 }

--- a/datamodel/config/datamodel_mapping_config.json
+++ b/datamodel/config/datamodel_mapping_config.json
@@ -11,7 +11,7 @@
         }
       }
     },
-    "alias" : {
+    "alias": {
       "description": "unique project name (auto-generated from MAGE-TAB file name)",
       "type": "string",
       "import": {
@@ -21,8 +21,11 @@
           "method": "import_string"
         },
         "hca": {
-          "path": ["alias"],
-          "from_type": "string",
+          "path": [
+            "project_json",
+            "project_core",
+            "project_short_name"
+          ],
           "method": "import_string"
         }
       }
@@ -37,8 +40,10 @@
           "method": "import_string"
         },
         "hca": {
-          "path": ["accession"],
-          "from_type": "string",
+          "path": [
+            "project_json",
+            "biostudies_accessions"
+          ],
           "method": "import_string"
         }
       }
@@ -53,8 +58,11 @@
           "method": "import_string"
         },
         "hca": {
-          "path": ["title"],
-          "from_type": "string",
+          "path": [
+            "project_json",
+            "project_core",
+            "project_title"
+          ],
           "method": "import_string"
         }
       }
@@ -64,15 +72,16 @@
       "type": "string",
       "import": {
         "ae": {
-          "parent": "project",
           "path": ["description"],
           "from_type": "string",
           "method": "import_string"
         },
         "hca": {
-          "parent": "project",
-          "path": ["description"],
-          "from_type": "string",
+          "path": [
+            "project_json",
+            "project_core",
+            "project_description"
+          ],
           "method": "import_string"
         }
       }
@@ -87,8 +96,11 @@
           "method": "import_string"
         },
         "hca": {
-          "path": ["releaseDate"],
-          "from_type": "string",
+          "path": [
+            "project_json",
+            "provenance",
+            "submission_date"
+          ],
           "method": "import_string"
         }
       }
@@ -96,38 +108,38 @@
     "publications": {
       "description": "list of Publication class objects",
       "type": "array",
-      "items": {
-        "$ref": "#/publication"
-      },
+      "items": "Publication",
       "import": {
         "ae": {
-          "path" : ["publications"],
+          "path": ["publications"],
           "from_type": "array",
           "method": "import_publication"
         },
         "hca": {
-          "path" : ["publications"],
-          "from_type": "array",
-          "method": "import_publication"
+          "path": [
+            "project_json",
+            "publications"
+          ],
+          "method": "import_nested_publications"
         }
       }
     },
     "contacts": {
       "description": "list of Contact class objects",
       "type": "array",
-      "items": {
-        "$ref": "#/definitions/contact"
-      },
+      "items": "Contact",
       "import": {
         "ae": {
-          "path" : ["contacts"],
+          "path": ["contacts"],
           "from_type": "array",
           "method": "import_contact"
         },
         "hca": {
-          "path" : ["contact"],
-          "from_type": "array",
-          "method": "import_contact"
+          "path": [
+            "project_json",
+            "contributors"
+          ],
+          "method": "import_nested_contacts"
         }
       }
     }
@@ -154,8 +166,11 @@
           "method": "import_string"
         },
         "hca": {
-          "path": ["alias"],
-          "from_type": "string",
+          "path": [
+            "project_json",
+            "project_core",
+            "project_short_name"
+          ],
           "method": "import_string"
         }
       }
@@ -170,28 +185,29 @@
           "method": "import_string"
         },
         "hca": {
-          "path": ["accession"],
-          "from_type": "string",
+          "path": [
+            "project_json",
+            "array_express_accessions"
+          ],
           "method": "import_string"
         }
       }
     },
     "title": {
-      "description": "Submitter provided study description",
+      "description": "submitter provided study description",
       "type": "string",
       "import": {
         "ae": {
-          "path": [
-            "title"
-          ],
+          "path": ["title"],
           "from_type": "string",
           "method": "import_string"
         },
         "hca": {
           "path": [
-            "title"
+            "project_json",
+            "project_core",
+            "project_title"
           ],
-          "from_type": "string",
           "method": "import_string"
         }
       }
@@ -201,17 +217,16 @@
       "type": "string",
       "import": {
         "ae": {
-          "path": [
-            "description"
-          ],
+          "path": ["description"],
           "from_type": "string",
           "method": "import_string"
         },
         "hca": {
           "path": [
-            "description"
+            "project_json",
+            "project_core",
+            "project_description"
           ],
-          "from_type": "string",
           "method": "import_string"
         }
       }
@@ -219,9 +234,7 @@
     "experimental_factor": {
       "description": "list of experimental factors as Attribute class objects",
       "type": "array",
-      "items": {
-        "$ref": "#definitions/attribute"
-      },
+      "items": "Attribute",
       "import": {
         "ae": {
           "path": [
@@ -236,9 +249,7 @@
     "experimental_design": {
       "description": "(optional) list of experimental designs as Attribute class objects",
       "type": "array",
-      "items": {
-        "$ref": "#definitions/attribute"
-      },
+      "items": "Attribute",
       "import": {
         "ae": {
           "path": [
@@ -253,8 +264,7 @@
     "experiment_type": {
       "description": "experiment type ontology terms",
       "type": "array",
-      "items": {
-      },
+      "items": "string",
       "import": {
         "ae": {
           "path": [
@@ -265,9 +275,9 @@
           "method": "get_string_from_attribute"
         },
         "hca": {
-          "path": ["experiment_type"],
-          "from_type": "string",
-          "method": "get_list_from_string"
+          "path": [],
+          "method": "use_translation",
+          "translation": "RNA-seq of coding RNA from single cells"
         }
       }
     },
@@ -284,29 +294,17 @@
           "method": "get_string_from_attribute"
         },
         "hca": {
-          "path": ["date_of_experiment"],
-          "from_type": "string",
-          "method": "import_string"
-        }
-      }
-    },
-    "protocolrefs": {
-      "description": "protocol accessions/name used in the study",
-      "type": "array",
-      "import": {
-        "ae": {
-          "path": ["protocolRefs"],
-          "from_type": "array",
-          "method": "get_reference_value_from_json"
-        },
-        "hca": {
-          "path": ["protocolrefs"],
-          "from_type": "array",
+          "path": [
+            "project_json",
+            "provenance",
+            "submission_date"
+          ],
           "method": "import_string"
         }
       }
     },
     "projectref": {
+      "description": "alias or accession of the project",
       "type": "string",
       "import": {
         "ae": {
@@ -315,9 +313,24 @@
           "method": "get_reference_value_from_json"
         },
         "hca": {
-          "path": ["projectref"],
+          "path": [],
+          "method": "placeholder"
+        }
+      }
+    },
+    "protocolrefs": {
+      "description": "protocol accessions/name used in the study",
+      "type": "array",
+      "items": "string",
+      "import": {
+        "ae": {
+          "path": ["protocolRefs"],
           "from_type": "array",
-          "method": "import_string"
+          "method": "get_reference_value_from_json"
+        },
+        "hca": {
+          "path": [],
+          "method": "placeholder"
         }
       }
     },
@@ -328,25 +341,46 @@
         "ae": {
           "path": [
             "attributes",
-            "study_type"
+            "submission_type"
           ],
           "from_type": "attribute_object",
           "method": "get_string_from_attribute"
         },
         "hca": {
-          "path": ["submission_type"],
-          "from_type": "string",
-          "method": "import_string"
+          "path": [],
+          "method": "use_translation",
+          "translation": "singlecell"
         }
       }
     },
     "secondary_accession": {
-      "description": "The accession number for the same study in another archive"
+      "description": "The accession number for the same study in another archive",
+      "type": "array",
+      "items": "string",
+      "import":{
+        "ae": {
+          "path": [
+            "attributes",
+            "secondary_accession"
+          ],
+          "method": "get_string_from_attribute"
+        }
+      }
     },
     "related_experiment": {
-      "description": "Accession numbers of other studies that are related to the current submission, e.g. for multi-omics studies"
-    },
-    "comments": {}
+      "description": "Accession numbers of other studies that are related to the current submission, e.g. for multi-omics studies",
+      "type": "array",
+      "items": "string",
+      "import": {
+        "ae": {
+          "path": [
+            "attributes",
+            "related_experiment"
+          ],
+          "method": "get_string_from_attribute"
+        }
+      }
+    }
   },
   "protocol": {
     "id": {
@@ -370,13 +404,15 @@
           "method": "import_string"
         },
         "hca": {
-          "path": ["alias"],
-          "from_type": "string",
-          "method": "import_string"
+          "path": [
+            "protocol_core",
+            "protocol_id"
+          ],
+          "method": "import_string_from_protocol"
         }
       }
     },
-    "accession":{
+    "accession": {
       "description": "ArrayExpress protocol accession",
       "type": "string",
       "import": {
@@ -384,6 +420,13 @@
           "path": ["accession"],
           "from_type": "string",
           "method": "import_string"
+        },
+        "hca": {
+          "path": [
+            "provenance",
+            "document_id"
+          ],
+          "method": "import_string_from_protocol"
         }
       }
     },
@@ -397,25 +440,31 @@
           "method": "import_string"
         },
         "hca": {
-          "path": ["description"],
-          "from_type": "string",
-          "method": "import_string"
+          "path": [
+            "protocol_core",
+            "protocol_description"
+          ],
+          "method": "import_string_from_protocol"
         }
       }
     },
     "protocol_type": {
       "description": "experiment type ontology term",
-      "type": "attribute_object",
+      "type": "Attribute",
       "import": {
         "ae": {
-          "path": ["attributes", "protocol_type"],
+          "path": [
+            "attributes",
+            "protocol_type"
+          ],
           "from_type": "array",
           "method": "generate_attribute_from_json"
         },
         "hca": {
-          "path": ["protocol_type"],
-          "from_type": "string",
-          "method": "generate_attribute_from_string"
+          "path": [
+            "describedBy"
+          ],
+          "method": "get_protocol_type"
         }
       }
     },
@@ -424,30 +473,33 @@
       "type": "string",
       "import": {
         "ae": {
-          "path": ["attributes", "hardware"],
+          "path": [
+            "attributes",
+            "hardware"
+          ],
           "from_type": "string",
           "method": "get_string_from_attribute"
         },
         "hca": {
-          "path": ["hardware"],
-          "from_type": "string",
-          "method": "import_string"
+          "path": [
+            "instrument_manufacturer_model",
+            "ontology_label"
+          ],
+          "method": "import_string_from_protocol"
         }
       }
     },
-    "software":{
+    "software": {
       "description": "free-text software description",
       "type": "string",
       "import": {
         "ae": {
-          "path": ["attributes", "software"],
+          "path": [
+            "attributes",
+            "software"
+          ],
           "from_type": "string",
           "method": "get_string_from_attribute"
-        },
-        "hca": {
-          "path": ["software"],
-          "from_type": "string",
-          "method": "import_string"
         }
       }
     },
@@ -456,14 +508,19 @@
       "type": "string",
       "import": {
         "ae": {
-          "path": ["attributes", "performer"],
+          "path": [
+            "attributes",
+            "performer"
+          ],
           "from_type": "string",
           "method": "get_string_from_attribute"
         },
         "hca": {
-          "path": ["performer"],
-          "from_type": "string",
-          "method": "import_string"
+          "path": [
+            "process_core",
+            "operators"
+          ],
+          "method": "get_protocol_operator"
         }
       }
     }
@@ -481,72 +538,125 @@
       }
     },
     "alias": {
+      "description": "sample name or alias",
       "type": "string",
       "import": {
         "ae": {
           "path": ["alias"],
           "from_type": "string",
           "method": "import_string"
+        },
+        "hca": {
+          "path": [
+            "biomaterial_core",
+            "biomaterial_id"
+          ],
+          "method": "lowest_biological_entity_get"
         }
       }
     },
     "accession": {
+      "description": "BioSamples accession",
       "type": "string",
       "import": {
         "ae": {
           "path": ["accession"],
           "from_type": "string",
           "method": "import_string"
+        },
+        "hca": {
+          "path": [
+            "biomaterial_core",
+            "biomaterial_id"
+          ],
+          "method": "lowest_biological_entity_get"
         }
       }
     },
     "taxon": {
+      "description": "latin species name as in NCBI taxonomy",
       "type": "string",
       "import": {
         "ae": {
           "path": ["taxon"],
           "from_type": "string",
           "method": "import_string"
+        },
+        "hca": {
+          "path": [
+            "genus_species",
+            "ontology_label"
+          ],
+          "method": "lowest_biological_entity_get"
         }
       }
     },
     "taxonId": {
-      "type": "string",
+      "description": "NCBI taxonomy identifier for the species",
+      "type": "integer",
       "import": {
         "ae": {
           "path": ["taxonId"],
           "from_type": "integer",
           "method": "import_string"
+        },
+        "hca": {
+          "path": [
+            "biomaterial_core",
+            "ncbi_taxon_id"
+          ],
+          "method": "lowest_biological_entity_get"
         }
       }
     },
     "material_type": {
+      "description": "(optional) one of: whole organism, organism part, cell, RNA, DNA",
       "type": "string",
       "import": {
         "ae": {
-          "path": ["attributes", "material_type"],
-          "from_type": "attribute_object",
+          "path": [
+            "attributes",
+            "material_type"
+          ],
+          "from_type": "Attribute",
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [],
+          "method": "get_sample_material_type"
         }
       }
     },
     "description": {
+      "description": "(optional) free-text description of sample",
       "type": "string",
       "import": {
         "ae": {
           "path": ["description"],
           "from_type": "string",
           "method": "import_string"
+        },
+        "hca": {
+          "path": [
+            "biomaterial_core",
+            "biomaterial_description"
+          ],
+          "method": "lowest_biological_entity_get"
         }
       }
     },
     "attributes": {
-      "type": "array",
+      "description": "dictionary of attribute categories as keys and Attribute class object as value",
+      "type": "object",
       "import": {
         "ae": {
           "path": ["attributes"],
           "from_type": "array",
           "method": "generate_sample_attribute_dict"
+        },
+        "hca": {
+          "path": [],
+          "method": "get_other_biomaterial_attributes"
         }
       }
     }
@@ -568,10 +678,7 @@
       "type": "string",
       "import": {
         "ae": {
-          "parent": "assay",
-          "path": [
-            "alias"
-          ],
+          "path": ["alias"],
           "from_type": "string",
           "method": "import_string"
         }
@@ -582,7 +689,6 @@
       "type": "string",
       "import": {
         "ae": {
-          "parent": "assay",
           "path": [
             "attributes",
             "technology_type"
@@ -595,12 +701,10 @@
     "protocolrefs": {
       "description": "protocol accessions/name used to generate assay data",
       "type": "array",
+      "items": "string",
       "import": {
         "ae": {
-          "parent": "assay",
-          "path": [
-            "protocolUses"
-          ],
+          "path": ["protocolUses"],
           "from_type": "array",
           "method": "get_reference_usage"
         }
@@ -611,10 +715,7 @@
       "type": "string",
       "import": {
         "ae": {
-          "parent": "assay",
-          "path": [
-            "sampleUses"
-          ],
+          "path": ["sampleUses"],
           "from_type": "array",
           "method": "get_reference_usage"
         }
@@ -625,7 +726,6 @@
       "type": "string",
       "import": {
         "ae": {
-          "parent": "assay",
           "path": [
             "attributes",
             "label"
@@ -668,7 +768,6 @@
       "type": "string",
       "import": {
         "ae": {
-          "parent": "assay",
           "path": [
             "alias"
           ],
@@ -692,7 +791,6 @@
       "type": "string",
       "import": {
         "ae": {
-          "parent": "assay",
           "path": [
             "attributes",
             "technology_type"
@@ -705,12 +803,10 @@
     "protocolrefs": {
       "description": "protocol accessions/name used to generate assay data",
       "type": "array",
+      "items": "string",
       "import": {
         "ae": {
-          "parent": "assay",
-          "path": [
-            "protocolUses"
-          ],
+          "path": ["protocolUses"],
           "from_type": "array",
           "method": "get_reference_usage"
         }
@@ -721,10 +817,7 @@
       "type": "string",
       "import": {
         "ae": {
-          "parent": "assay",
-          "path": [
-            "sampleUses"
-          ],
+          "path": ["sampleUses"],
           "from_type": "array",
           "method": "get_reference_usage"
         }
@@ -848,12 +941,13 @@
       "type": "string",
       "import": {
         "ae": {
-          "parent": "assay",
-          "path": [
-            "alias"
-          ],
+          "path": ["alias"],
           "from_type": "string",
           "method": "import_string"
+        },
+        "hca": {
+          "path": [],
+          "method": "get_hca_bundle_uuid"
         }
       }
     },
@@ -879,20 +973,27 @@
           ],
           "from_type": "string",
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [],
+          "method": "use_translation",
+          "translation": "sequencing assay"
         }
       }
     },
     "protocolrefs": {
       "description": "protocol accessions/name used to generate assay data",
       "type": "array",
+      "items": "string",
       "import": {
         "ae": {
-          "parent": "assay",
-          "path": [
-            "protocolUses"
-          ],
+          "path": ["protocolUses"],
           "from_type": "array",
           "method": "get_reference_usage"
+        },
+        "hca": {
+          "path": [],
+          "method": "placeholder"
         }
       }
     },
@@ -902,11 +1003,13 @@
       "import": {
         "ae": {
           "parent": "assay",
-          "path": [
-            "sampleUses"
-          ],
+          "path": ["sampleUses"],
           "from_type": "array",
           "method": "get_reference_usage"
+        },
+        "hca": {
+          "path": [],
+          "method": "placeholder"
         }
       }
     },
@@ -917,6 +1020,14 @@
         "ae": {
           "path": ["attributes", "library_layout"],
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": ["sequencing_protocol_json", "paired_end"],
+          "method": "use_translation",
+          "translation": {
+            "True": "PAIRED",
+            "False": "SINGLE"
+          }
         }
       }
     },
@@ -927,6 +1038,11 @@
         "ae": {
           "path": ["attributes", "library_source"],
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [],
+          "method": "use_translation",
+          "translation": "transcriptomic single cell"
         }
       }
     },
@@ -937,6 +1053,11 @@
         "ae": {
           "path": ["attributes", "library_strategy"],
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [],
+          "method": "use_translation",
+          "translation": "RNA-Seq"
         }
       }
     },
@@ -947,6 +1068,11 @@
         "ae": {
           "path": ["attributes", "library_selection"],
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [],
+          "method": "use_translation",
+          "translation": "cDNA"
         }
       }
     },
@@ -957,6 +1083,13 @@
         "ae": {
           "path": ["attributes", "nominal_length"],
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [
+            "library_preparation_protocol_json",
+            "nominal_length"
+          ],
+          "method": "import_string"
         }
       }
     },
@@ -967,6 +1100,13 @@
         "ae": {
           "path": ["attributes", "nominal_sdev"],
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [
+            "library_preparation_protocol_json",
+            "nominal_sdev"
+          ],
+          "method": "import_string"
         }
       }
     },
@@ -987,6 +1127,14 @@
         "ae": {
           "path": ["attributes", "platform_type"],
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [
+            "sequencing_protocol_json",
+            "method",
+            "ontology_label"
+          ],
+          "method": "import_string"
         }
       }
     },
@@ -997,6 +1145,14 @@
         "ae": {
           "path": ["attributes", "instrument_model"],
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [
+            "sequencing_protocol_json",
+            "instrument_manufacturer_model",
+            "ontology_label"
+          ],
+          "method": "import_string"
         }
       }
     },
@@ -1007,6 +1163,19 @@
         "ae": {
           "path": ["attributes", "library_strand"],
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [
+            "library_preparation_protocol_json",
+            "strand"
+          ],
+          "method": "use_translation",
+          "translation": {
+            "unstranded": "not applicable",
+            "first": "first strand",
+            "second": "second strand",
+            "not provided": "not provided"
+          }
         }
       }
     },
@@ -1017,16 +1186,39 @@
         "ae": {
           "path": ["attributes", "single_cell_isolation"],
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [
+            "dissociation_protocol_json",
+            "method",
+            "ontology_label"
+          ],
+          "method": "use_translation",
+          "translation": {
+            "fluorescence-activated cell sorting": "FACS",
+            "10X v2 sequencing": "10x",
+            "enzymatic dissociation": "enzymatic dissociation",
+            "mechanical dissociation": "mechanical dissociation",
+            "None": "null"
+          }
         }
       }
     },
     "library_construction": {
       "description": "The protocol that was followed to generate single-cell libraries",
-        "type": "string",
+      "type": "string",
       "import": {
         "ae": {
           "path": ["attributes", "library_construction"],
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [
+            "library_preparation_protocol_json",
+            "library_construction_method",
+            "ontology_label"
+          ],
+          "method": "import_string"
         }
       }
     },
@@ -1037,10 +1229,19 @@
         "ae": {
           "path": ["attributes", "input_molecule"],
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [
+            "library_preparation_protocol_json",
+            "input_nucleic_acid_molecule",
+            "ontology_label"
+          ],
+          "method": "import_string"
         }
       }
     },
     "end_bias": {
+      "description": "The end of the nucleic acid molecule that is preferentially sequenced (bias in read distribution)",
       "type": "string",
       "import": {
         "ae": {
@@ -1050,87 +1251,167 @@
       }
     },
     "primer": {
+      "description": "The type of primer used for reverse-transcription",
       "type": "string",
       "import": {
         "ae": {
           "path": ["attributes", "primer"],
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [
+            "library_preparation_protocol_json",
+            "end_bias"
+          ],
+          "method": "import_string"
         }
       }
     },
     "spike_in": {
+      "description": "The type of spike-in set that was added to the library.",
       "type": "string",
       "import": {
         "ae": {
           "path": ["attributes", "spike_in"],
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [
+            "library_preparation_protocol_json",
+            "spike_in_kit",
+            "ontology_label"
+          ],
+          "method": "import_string"
         }
       }
     },
     "spike_in_dilution": {
+      "description": "final dilution ratio of the spike-in mix, e.g. 1:20000",
       "type": "string",
       "import": {
         "ae": {
           "path": ["attributes", "spike_in_dilution"],
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [
+            "library_preparation_protocol_json",
+            "spike_in_dilution"
+          ],
+          "method": "import_string"
         }
       }
     },
     "umi_barcode_read": {
+      "description": "The read type that contains the unique molecular identifier (UMI) barcode",
       "type": "string",
       "import": {
         "ae": {
           "path": ["attributes", "umi_barcode_read"],
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [
+            "library_preparation_protocol_json",
+            "umi_barcode",
+            "barcode_read"
+          ],
+          "method": "import_string"
         }
       }
     },
     "umi_barcode_size": {
+      "description": "Length of unique molecular identifier (UMI) barcode read",
       "type": "string",
       "import": {
         "ae": {
           "path": ["attributes", "umi_barcode_size"],
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [
+            "library_preparation_protocol_json",
+            "umi_barcode",
+            "barcode_length"
+          ],
+          "method": "import_string"
         }
       }
     },
     "umi_barcode_offset": {
+      "description": "Offset in sequence for unique molecular identifier (UMI) barcode read",
       "type": "string",
       "import": {
         "ae": {
           "path": ["attributes", "umi_barcode_offset"],
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [
+            "library_preparation_protocol_json",
+            "umi_barcode",
+            "barcode_offset"
+          ],
+          "method": "import_string"
         }
       }
     },
     "cell_barcode_read": {
+      "description": "The read type that contains the cell barcode read",
       "type": "string",
       "import": {
         "ae": {
           "path": ["attributes", "cell_barcode_read"],
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [
+            "library_preparation_protocol_json",
+            "cell_barcode",
+            "barcode_read"
+          ],
+          "method": "import_string"
         }
       }
     },
     "cell_barcode_size": {
+      "description": "Length of cell barcode read",
       "type": "string",
       "import": {
         "ae": {
           "path": ["attributes", "cell_barcode_size"],
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [
+            "library_preparation_protocol_json",
+            "cell_barcode",
+            "barcode_length"
+          ],
+          "method": "import_string"
         }
       }
     },
     "cell_barcode_offset": {
+      "description": "Offset in sequence for cell barcode read",
       "type": "string",
       "import": {
         "ae": {
           "path": ["attributes", "cell_barcode_offset"],
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [
+            "library_preparation_protocol_json",
+            "cell_barcode",
+            "barcode_offset"
+          ],
+          "method": "import_string"
         }
       }
     },
     "cDNA_read": {
+      "description": "The read type that contains the cDNA read",
       "type": "string",
       "import": {
         "ae": {
@@ -1140,6 +1421,7 @@
       }
     },
     "cDNA_read_offset": {
+      "description": "Offset in sequence for cDNA read",
       "type": "string",
       "import": {
         "ae": {
@@ -1149,6 +1431,7 @@
       }
     },
     "cDNA_read_size": {
+      "description": "Length of cDNA read",
       "type": "string",
       "import": {
         "ae": {
@@ -1158,6 +1441,7 @@
       }
     },
     "sample_barcode_read": {
+      "description": "the read type that contains the sample barcode read",
       "type": "string",
       "import": {
         "ae": {
@@ -1167,6 +1451,7 @@
       }
     },
     "sample_barcode_size": {
+      "description": "Length of sample barcode read",
       "type": "string",
       "import": {
         "ae": {
@@ -1176,6 +1461,7 @@
       }
     },
     "sample_barcode_offset": {
+      "description": "Offset in sequence for sample barcode read",
       "type": "string",
       "import": {
         "ae": {
@@ -1205,32 +1491,37 @@
         }
       }
     },
-     "alias": {
-       "description": "unique name in the experiment (Assay Name in SDRF)",
-       "type": "string",
-       "import": {
-         "ae": {
-           "from_type": "string",
-           "parent": "assay_data",
-           "path": ["alias"],
-           "method": "import_string"
-         }
-       }
-     },
+    "alias": {
+      "description": "unique name in the experiment (Assay Name in SDRF)",
+      "type": "string",
+      "import": {
+        "ae": {
+          "from_type": "string",
+          "parent": "assay_data",
+          "path": ["alias"],
+          "method": "import_string"
+        },
+        "hca": {
+          "path": [],
+          "method": "get_hca_bundle_uuid"
+        }
+      }
+    },
     "files": {
       "description": "list of DataFile class objects",
       "type": "array",
-      "items": {
-        "$ref": "#/data_file"
-      },
+      "items": "DataFile",
       "import": {
         "ae": {
           "from_type": "array",
-          "parent": "assay_data",
-          "path": [
-            "files"
-          ],
+          "path": ["files"],
           "method": "import_file"
+        },
+        "hca": {
+          "path": [
+            "sequence_file_json"
+          ],
+          "method": "import_nested_data_files"
         }
       }
     },
@@ -1240,43 +1531,53 @@
       "import": {
         "ae": {
           "from_type": "string",
-          "parent": "assay_data",
           "path": [
             "attributes",
             "data_type"
           ],
           "method": "get_string_from_attribute"
+        },
+        "hca": {
+          "path": [],
+          "method": "use_translation",
+          "translation": "raw"
         }
       }
     },
     "assayrefs": {
       "description": "assay name/accessions",
       "type": "array",
+      "items": "string",
       "import": {
         "ae": {
           "from_type": "array",
-          "parent": "assay_data",
-          "path": [
-            "assayRefs"
-          ],
+          "path": ["assayRefs"],
           "method": "get_reference_value_from_json"
+        },
+        "hca": {
+          "path": [],
+          "method": "placeholder"
         }
       }
     },
     "protocolrefs": {
       "description": "protocol name/accessions used to generate data file",
-      "type": "array"
-      },
+      "type": "array",
+      "items": "string",
+      "import": {
+        "ae": {
+          "path": ["protocolUses"],
+          "method": "get_reference_usage"
+        }
+      }
+    },
     "accession": {
       "description": "(not for microarray) ENA run accession",
       "type": "string",
       "import": {
         "ae": {
           "from_type": "string",
-          "parent": "assay_data",
-          "path": [
-            "accession"
-          ],
+          "path": ["accession"],
           "method": "import_string"
         }
       }
@@ -1298,27 +1599,21 @@
       "description": "unique name in the experiment (auto-generated from processed file name in SDRF)",
       "type": "string",
       "import": {
-         "ae": {
-           "from_type": "string",
-           "parent": "analysis",
-           "path": ["alias"],
-           "method": "import_string"
-         }
-       }
+        "ae": {
+          "from_type": "string",
+          "path": ["alias"],
+          "method": "import_string"
+        }
+      }
     },
     "files": {
       "description": "list of DataFile class objects",
       "type": "array",
-      "items": {
-        "$ref": "#/data_file"
-      },
+      "items": "DataFile",
       "import": {
         "ae": {
           "from_type": "array",
-          "parent": "analysis",
-          "path": [
-            "files"
-          ],
+          "path": ["files"],
           "method": "import_file"
         }
       }
@@ -1329,7 +1624,6 @@
       "import": {
         "ae": {
           "from_type": "string",
-          "parent": "analysis",
           "path": [
             "attributes",
             "data_type"
@@ -1341,13 +1635,11 @@
     "assayrefs": {
       "description": "list of assay data name/accessions",
       "type": "array",
+      "items": "string",
       "import": {
         "ae": {
           "from_type": "array",
-          "parent": "assay_data",
-          "path": [
-            "assayRefs"
-          ],
+          "path": ["assayRefs"],
           "method": "get_reference_value_from_json"
         }
       }
@@ -1355,13 +1647,12 @@
     "assaydatarefs": {
       "description": "list of assay data name/accessions",
       "type": "array",
+      "items": "string",
       "import": {
         "ae": {
           "from_type": "array",
           "parent": "assay_data",
-          "path": [
-            "assayDataRefs"
-          ],
+          "path": ["assayDataRefs"],
           "method": "get_reference_value_from_json"
         }
       }
@@ -1369,13 +1660,11 @@
     "protocolrefs": {
       "description": "list of protocol name/accessions used to generate data file",
       "type": "array",
+      "items": "string",
       "import": {
         "ae": {
           "from_type": "array",
-          "parent": "assay_data",
-          "path": [
-            "protocolUses"
-          ],
+          "path": ["protocolUses"],
           "method": "get_reference_usage"
         }
       }
@@ -1386,10 +1675,15 @@
       "type": "string",
       "import": {
         "ae": {
-          "parent": "publication",
           "path": ["articleTitle"],
-          "from_type": "sting",
+          "from_type": "string",
           "method": "import_string"
+        },
+        "hca": {
+          "path": [
+            "title"
+          ],
+          "method": "import_string_from_selected_entity"
         }
       }
     },
@@ -1397,10 +1691,15 @@
       "type": "string",
       "import": {
         "ae": {
-          "parent": "publication",
           "path": ["authors"],
-          "from_type": "sting",
+          "from_type": "string",
           "method": "import_string"
+        },
+        "hca": {
+          "path": [
+            "authors"
+          ],
+          "method": "import_string_from_selected_entity"
         }
       }
     },
@@ -1408,10 +1707,14 @@
       "type": "string",
       "import": {
         "ae": {
-          "parent": "publication",
           "path": ["pubmedId"],
-          "from_type": "integer",
           "method": "import_string"
+        },
+        "hca": {
+          "path": [
+            "pmid"
+          ],
+          "method": "import_string_from_selected_entity"
         }
       }
     },
@@ -1419,10 +1722,15 @@
       "type": "string",
       "import": {
         "ae": {
-          "parent": "publication",
           "path": ["doi"],
-          "from_type": "sting",
+          "from_type": "string",
           "method": "import_string"
+        },
+        "hca": {
+          "path": [
+            "doi"
+          ],
+          "method": "import_string_from_selected_entity"
         }
       }
     },
@@ -1430,12 +1738,11 @@
       "type": "string",
       "import": {
         "ae": {
-          "parent": "publication",
           "path": ["publicationStatus"],
-          "from_type": "sting",
+          "from_type": "string",
           "method": "import_string",
           "translation": {
-            "Unknown" : "",
+            "Unknown": "",
             "InPreparation": "in preparation",
             "Submitted": "submitted",
             "Published": "published"
@@ -1445,25 +1752,35 @@
     }
   },
   "contact": {
-    "firstName":{
+    "firstName": {
       "type": "string",
       "import": {
         "ae": {
-          "parent": "contact",
           "path": ["firstName"],
-          "from_type": "sting",
+          "from_type": "string",
           "method": "import_string"
+        },
+        "hca": {
+          "path": [
+            "name"
+          ],
+          "method": "import_first_name"
         }
       }
     },
-    "lastName":{
+    "lastName": {
       "type": "string",
       "import": {
         "ae": {
-          "parent": "contact",
           "path": ["lastName"],
-          "from_type": "sting",
+          "from_type": "string",
           "method": "import_string"
+        },
+        "hca": {
+          "path": [
+            "name"
+          ],
+          "method": "import_last_name"
         }
       }
     },
@@ -1471,10 +1788,15 @@
       "type": "string",
       "import": {
         "ae": {
-          "parent": "contact",
           "path": ["email"],
-          "from_type": "sting",
+          "from_type": "string",
           "method": "import_string"
+        },
+        "hca": {
+          "path": [
+            "email"
+          ],
+          "method": "import_string_from_selected_entity"
         }
       }
     },
@@ -1482,10 +1804,15 @@
       "type": "string",
       "import": {
         "ae": {
-          "parent": "contact",
           "path": ["affiliation"],
-          "from_type": "sting",
+          "from_type": "string",
           "method": "import_string"
+        },
+        "hca": {
+          "path": [
+            "institution"
+          ],
+          "method": "import_string_from_selected_entity"
         }
       }
     },
@@ -1493,10 +1820,15 @@
       "type": "string",
       "import": {
         "ae": {
-          "parent": "contact",
           "path": ["address"],
-          "from_type": "sting",
+          "from_type": "string",
           "method": "import_string"
+        },
+        "hca": {
+          "path": [
+            "address"
+          ],
+          "method": "import_string_from_selected_entity"
         }
       }
     },
@@ -1504,21 +1836,33 @@
       "type": "string",
       "import": {
         "ae": {
-          "parent": "contact",
           "path": ["phone"],
-          "from_type": "sting",
+          "from_type": "string",
           "method": "import_string"
+        },
+        "hca": {
+          "path": [
+            "phone"
+          ],
+          "method": "import_string_from_selected_entity"
         }
       }
     },
     "roles": {
       "type": "array",
+      "items": "string",
       "import": {
         "ae": {
-          "parent": "contact",
           "path": ["roles"],
           "from_type": "array",
           "method": "import_string"
+        },
+        "hca": {
+          "path": [
+            "project_role",
+            "ontology_label"
+          ],
+          "method": "import_string_from_selected_entity"
         }
       }
     },
@@ -1526,20 +1870,23 @@
       "type": "string",
       "import": {
         "ae": {
-          "parent": "contact",
           "path": ["middleInitials"],
-          "from_type": "sting",
+          "from_type": "string",
           "method": "import_string"
+        },
+        "hca": {
+          "path": [
+            "name"
+          ],
+          "method": "get_middle_initial"
         }
       }
     },
     "fax": {
-      "type": "array",
+      "type": "string",
       "import": {
         "ae": {
-          "parent": "contact",
           "path": ["fax"],
-          "from_type": "array",
           "method": "import_string"
         }
       }
@@ -1548,9 +1895,7 @@
       "type": "string",
       "import": {
         "ae": {
-          "parent": "contact",
           "path": ["orcid"],
-          "from_type": "string",
           "method": "import_string"
         }
       }
@@ -1566,6 +1911,13 @@
             "name"
           ],
           "method": "import_string"
+        },
+        "hca": {
+          "path": [
+            "file_core",
+            "file_name"
+          ],
+          "method": "import_string_from_selected_entity"
         }
       }
     },
@@ -1578,6 +1930,13 @@
             "checksum"
           ],
           "method": "import_string"
+        },
+        "hca": {
+          "path": [
+            "file_core",
+            "checksum"
+          ],
+          "method": "import_string_from_selected_entity"
         }
       }
     },
@@ -1586,10 +1945,13 @@
       "import": {
         "ae": {
           "from_type": "string",
-          "path": [
-            "checksumMethod"
-          ],
+          "path": ["checksumMethod"],
           "method": "import_string"
+        },
+        "hca": {
+          "path": [],
+          "method": "use_translation",
+          "translation": "MD5"
         }
       }
     },
@@ -1598,9 +1960,7 @@
       "import": {
         "ae": {
           "from_type": "string",
-          "path": [
-            "ftp_location"
-          ],
+          "path": ["ftp_location"],
           "method": "import_string"
         }
       }
@@ -1610,97 +1970,14 @@
       "type": "string",
       "import": {
         "ae": {
-          "path": ["attributes", "read_type"]
-        }
-      }
-    }
-  },
-  "submittables": {
-    "project": {
-      "import": {
-        "ae": {
-          "path": ["projects"],
-          "method": "get_first_object_from_list"
+          "path": ["attributes", "read_type"],
+          "method": "import_string"
         },
         "hca": {
-          "path": ["project"],
-          "method": "get_first_object_from_list"
-        }
-      }
-    },
-    "study": {
-      "import": {
-        "ae": {
-          "path": ["studies"],
-          "method": "get_first_object_from_list"
-        },
-        "hca": {
-          "path": ["study"],
-          "method": "get_first_object_from_list"
-        }
-      }
-    },
-    "protocol": {
-      "import": {
-        "ae": {
-          "path": ["protocols"],
-          "method": "import_as_is"
-        },
-        "hca": {
-          "path": ["protocol"],
-          "method": "import_as_is"
-        }
-      }
-    },
-    "sample": {
-      "import": {
-        "ae": {
-          "path": ["samples"],
-          "method": "import_as_is"
-        },
-        "hca": {
-          "path": ["sample"],
-          "method": "import_as_is"
-        }
-      }
-    },
-    "assay": {
-      "import": {
-        "ae": {
-          "path": ["assays"],
-          "method": "import_as_is"
-        },
-        "hca": {
-          "path": ["singlecell_assay"],
-          "method": "import_as_is"
-        }
-      }
-    },
-    "assay_data": {
-      "import": {
-        "ae": {
-          "path": ["assayData"],
-          "method": "import_as_is"
-        },
-        "hca": {
-          "path": ["assay_data"],
-          "method": "import_as_is"
-        }
-      }
-    },
-    "analysis": {
-      "import": {
-        "ae": {
-          "path": ["analyses"],
-          "method": "import_as_is"
-        }
-      }
-    },
-    "submission": {
-      "import": {
-        "ae": {
-          "path": ["submission"],
-          "method": "import_as_is"
+          "path": [
+            "read_index"
+          ],
+          "method": "import_string_from_selected_entity"
         }
       }
     }


### PR DESCRIPTION
This is an update to the configuration file.
It now has:
- Import rules for HCA JSON input
- Whenever the type is "array", items description have been added that list the type of object (e.g. Python class name for custom items) in the array
- Descriptions for all main object attributes
- The config now successfully maps against the schema