### PR TITLE
Change taxonId type to string

### DIFF
--- a/datamodel/config/datamodel_mapping_config.json
+++ b/datamodel/config/datamodel_mapping_config.json
@@ -593,7 +593,7 @@
     },
     "taxonId": {
       "description": "NCBI taxonomy identifier for the species",
-      "type": "integer",
+      "type": "string",
       "import": {
         "ae": {
           "path": ["taxonId"],

--- a/datamodel/sample.py
+++ b/datamodel/sample.py
@@ -8,7 +8,7 @@ class Sample(AccessionedSubmittable):
        :param alias: string, unique sample name in the experiment
        :param accession: string, BioSamples accession
        :param taxon: string, latin species name
-       :param taxonId: int, NCBI taxonomy identifier for the species
+       :param taxonId: str, NCBI taxonomy identifier for the species
        :param attributes: dictionary of attribute categories as keys and Attribute class object as value
        :param material_type: string, (optional) one of: whole organism, organism part, cell, RNA, DNA
        :param description: string, (optional) free-text description of sample
@@ -16,7 +16,7 @@ class Sample(AccessionedSubmittable):
     def __init__(self, **kwargs):
         AccessionedSubmittable.__init__(self, **kwargs)
         self.taxon: str = kwargs.get("taxon")
-        self.taxonId: int = kwargs.get("taxonId")
+        self.taxonId: str = kwargs.get("taxonId")
         self.material_type: str = kwargs.get("material_type")
         self.attributes: dict = kwargs.get("attributes", {})
 


### PR DESCRIPTION
To be be consistently dealing with strings as the base type of all metadata values, I've decided to change the type of the taxon ID from integer to string.