### PR TITLE
Correct method for importing read_type file attribute

### DIFF
--- a/datamodel/config/datamodel_mapping_config.json
+++ b/datamodel/config/datamodel_mapping_config.json
@@ -375,7 +375,7 @@
         "ae": {
           "path": [
             "attributes",
-            "related_experiment"
+            "related_study"
           ],
           "method": "get_string_from_attribute"
         }
@@ -1971,7 +1971,7 @@
       "import": {
         "ae": {
           "path": ["attributes", "read_type"],
-          "method": "import_string"
+          "method": "get_string_from_attribute"
         },
         "hca": {
           "path": [


### PR DESCRIPTION
I've updated the method of the file attribute "read_type" because it will be a custom attribute, which will go under "attributes" in the USI JSON, therefore I need the get string form attribute method. 
I've also changed the name of the AE custom attribute "related_experiment" to "related_study" as experiments are known as studies in the USI world.