### PR TITLE
Add Single Cell Expression Atlas comments to study attributes

### DIFF
--- a/datamodel/config/datamodel_mapping_config.json
+++ b/datamodel/config/datamodel_mapping_config.json
@@ -385,6 +385,62 @@
           "method": "get_string_from_attribute"
         }
       }
+    },
+    "ea_curator": {
+      "description": "Name of Expression Atlas curator",
+      "type": "array",
+      "items": "string",
+      "import": {
+        "ae": {
+          "path": [
+            "attributes",
+            "ea_curator"
+          ],
+          "method": "get_string_from_attribute"
+        }
+      }
+    },
+    "ea_experiment_type": {
+      "description": "Single Cell Expression Atlas analysis type",
+      "type": "array",
+      "items": "string",
+      "import": {
+        "ae": {
+          "path": [
+            "attributes",
+            "ea_experiment_type"
+          ],
+          "method": "get_string_from_attribute"
+        }
+      }
+    },
+    "ea_additional_attributes": {
+      "description": "Attribute names to be visualised in single cell plot",
+      "type": "array",
+      "items": "string",
+      "import": {
+        "ae": {
+          "path": [
+            "attributes",
+            "ea_additional_attributes"
+          ],
+          "method": "get_string_from_attribute"
+        }
+      }
+    },
+    "ea_expected_clusters": {
+      "description": "Number of cell clusters expected in a single cell experiment",
+      "type": "array",
+      "items": "string",
+      "import": {
+        "ae": {
+          "path": [
+            "attributes",
+            "ea_expected_clusters"
+          ],
+          "method": "get_string_from_attribute"
+        }
+      }
     }
   },
   "protocol": {

--- a/datamodel/study.py
+++ b/datamodel/study.py
@@ -22,6 +22,10 @@ class Study(AccessionedSubmittable):
     :param submission_type: string, submission type (microarray, sequencing, singlecell)
     :param secondary_accession: list, accession of the same study in another archive (e.g. ENA)
     :param related_experiment: list, accession of experiments related to this study
+    :param ea_curator: list, name of Expression Atlas curator
+    :param ea_experiment_type: list, Single Cell Expression Atlas analysis type
+    :param ea_additional_attributes: list, attribute names to be visualised in single cell plot
+    :param ea_expected_clusters: list, number of cell clusters expected in a single cell experiment
     :param comments: dictionary, (optional) known IDF comments
                     keys: string, comment category
                     values: list, comment values
@@ -38,5 +42,9 @@ class Study(AccessionedSubmittable):
         self.submission_type: str = kwargs.get("submission_type")
         self.secondary_accession: List[str] = kwargs.get("secondary_accession", [])
         self.related_experiment: List[str] = kwargs.get("related_experiment", [])
+        self.ea_curator: List[str] = kwargs.get("ea_curator", [])
+        self.ea_experiment_type: List[str] = kwargs.get("ea_experiment_type", [])
+        self.ea_additional_attributes: List[str] = kwargs.get("ea_additional_attributes", [])
+        self.ea_expected_clusters: List[str] = kwargs.get("ea_expected_clusters", [])
         self.comments: dict = kwargs.get("comments", {})
 


### PR DESCRIPTION
For Single Cell Expression Atlas the MAGE-TAB contains a few extra comment fields, e.g. in the IDF to set parameters for the downstream analysis. To reliably export these fields, they need to be included in the common data model as well. 